### PR TITLE
Added color attribute to toolbar

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,1 +1,1 @@
-<mat-toolbar>Server Name Selector</mat-toolbar>
+<mat-toolbar color="primary">Server Name Selector</mat-toolbar>


### PR DESCRIPTION
TIL that Angular Material themes aren't auto applied. You actually have to specify color tokens that you want to use.